### PR TITLE
oxlint json parse failure fallback

### DIFF
--- a/.changeset/fresh-suits-glow.md
+++ b/.changeset/fresh-suits-glow.md
@@ -1,0 +1,5 @@
+---
+"@bomb.sh/tools": patch
+---
+
+In some failure or no-op cases, oxlint seems to return output which is not json-parseable even with --json passed. Log output directly in these instances.

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -25,24 +25,31 @@ export async function runOxlint(targets: string[], fix?: boolean): Promise<Viola
 	const args = ['-c', oxlintConfig, '--format=json', ...targets];
 	if (fix) args.push('--fix');
 	const result = await x(local('oxlint'), args, { throwOnError: false });
-	const json = JSON.parse(result.stdout);
-	return (json.diagnostics ?? []).map(
-		(d: {
-			message: string;
-			code: string;
-			severity: string;
-			filename?: string;
-			labels?: Array<{ span?: { line?: number; column?: number } }>;
-		}) => ({
-			tool: 'oxlint' as const,
-			level: d.severity === 'error' ? 'error' : 'warning',
-			code: d.code ?? 'unknown',
-			message: d.message,
-			file: d.filename,
-			line: d.labels?.[0]?.span?.line,
-			column: d.labels?.[0]?.span?.column,
-		}),
-	);
+	try {
+		const json = JSON.parse(result.stdout);
+		return (json.diagnostics ?? []).map(
+			(d: {
+				message: string;
+				code: string;
+				severity: string;
+				filename?: string;
+				labels?: Array<{ span?: { line?: number; column?: number } }>;
+			}) => ({
+				tool: 'oxlint' as const,
+				level: d.severity === 'error' ? 'error' : 'warning',
+				code: d.code ?? 'unknown',
+				message: d.message,
+				file: d.filename,
+				line: d.labels?.[0]?.span?.line,
+				column: d.labels?.[0]?.span?.column,
+			}),
+		);
+	} catch {
+		// in some cases, failures or no-ops do not produce valid JSON
+		// fallback to raw output rather than throwing an error
+		console.log(result.stdout);
+		return [];
+	}
 }
 
 export async function runKnip(): Promise<Violation[]> {


### PR DESCRIPTION
## What does this PR do?

In some failure or no-op cases, oxlint seems to return output which is not json-parseable even with `--json` passed. I suspect these are mostly edge cases which we don't highly value handling. Went with a simple try/catch and log out the result instead.

### Example 

```shell
https://github.com/bombshell-dev/repo v0.0.0 using v22.14.0
❯ pnpm lint

> @bomb.sh/ui-workspace@0.0.0 lint /dev/github/bombshell-dev/repo
> bsh lint

SyntaxError: Unexpected token 'N', "No files f"... is not valid JSON
    at JSON.parse (<anonymous>)
    at runOxlint (file:///dev/github/bombshell-dev/repo/node_modules/.pnpm/@bomb.sh+tools@0.5.1_oxc-resolver@11.20.0_vite@8.0.16_jiti@2.7.0_yaml@2.9.0_/node_modules/@bomb.sh/tools/dist/commands/lint.mjs:16:15)
    at async Promise.allSettled (index 0)
    at async collectViolations (file:///dev/github/bombshell-dev/repo/node_modules/.pnpm/@bomb.sh+tools@0.5.1_oxc-resolver@11.20.0_vite@8.0.16_jiti@2.7.0_yaml@2.9.0_/node_modules/@bomb.sh/tools/dist/commands/lint.mjs:149:18)
    at async lint (file:///dev/github/bombshell-dev/repo/node_modules/.pnpm/@bomb.sh+tools@0.5.1_oxc-resolver@11.20.0_vite@8.0.16_jiti@2.7.0_yaml@2.9.0_/node_modules/@bomb.sh/tools/dist/commands/lint.mjs:172:21)
    at async main (file:///dev/github/bombshell-dev/repo/node_modules/.pnpm/@bomb.sh+tools@0.5.1_oxc-resolver@11.20.0_vite@8.0.16_jiti@2.7.0_yaml@2.9.0_/node_modules/@bomb.sh/tools/dist/bin.mjs:33:2)

packages/new-pkg/src/index.ts
  -       warning     Unused file  knip/unused-file

1 warning
```

### Result

```shell
https://github.com/bombshell-dev/repo on main [!] v0.0.0 using v22.14.0 took 2s
❯ pnpm lint

> @bomb.sh/new-repo-workspace@0.0.0 lint /dev/github/bombshell-dev/repo
> bsh lint

No files found to lint. Please check your paths and ignore patterns.
{ "diagnostics": [],
              "number_of_files": 0,
              "number_of_rules": 145,
              "threads_count": 8,
              "start_time": 0.084649375
            }


No issues found.
```

## Type of change

<!-- Check one. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] All tests pass (`pnpm test`)
- [x] Files are formatted (`pnpm format`)
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
