### PR TITLE
fix init

### DIFF
--- a/.changeset/fix-init-clone-dest.md
+++ b/.changeset/fix-init-clone-dest.md
@@ -1,0 +1,9 @@
+---
+"@bomb.sh/tools": patch
+---
+
+fix(init): read postprocessed files from the actual clone target, scaffold `.` in-place
+
+`init <name>` cloned the template into `./<name>/` but postprocessed `package.json`/`README.md` from a stale hardcoded `./.temp/` path, crashing with `ENOENT`. The destination now points at the directory the template was actually cloned into.
+
+`init` / `init .` now scaffolds into the current directory in-place (via giget `--force`) and derives the project name from the current directory's basename, instead of cloning into a mis-named subdirectory.

--- a/.changeset/fix-init-clone-dest.md
+++ b/.changeset/fix-init-clone-dest.md
@@ -2,8 +2,6 @@
 "@bomb.sh/tools": patch
 ---
 
-fix(init): read postprocessed files from the actual clone target, scaffold `.` in-place
+Fixes the `bsh init` command—it now points at the directory the template was actually cloned into.
 
-`init <name>` cloned the template into `./<name>/` but postprocessed `package.json`/`README.md` from a stale hardcoded `./.temp/` path, crashing with `ENOENT`. The destination now points at the directory the template was actually cloned into.
-
-`init` / `init .` now scaffolds into the current directory in-place (via giget `--force`) and derives the project name from the current directory's basename, instead of cloning into a mis-named subdirectory.
+`init` / `init .` now scaffolds into the current directory in-place and uses the current directory's basename as the project name.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from 'node:fs/promises';
+import { basename } from 'node:path';
 import { cwd } from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { x } from 'tinyexec';
@@ -7,10 +8,15 @@ import type { CommandContext } from '../context.ts';
 export async function init(ctx: CommandContext) {
 	const [_name = '.'] = ctx.args;
 	const cwdUrl = pathToFileURL(`${cwd()}/`);
-	const name =
-		_name === '.' ? new URL('../', cwdUrl).pathname.split('/').filter(Boolean).pop()! : _name;
-	const dest = new URL('./.temp/', cwdUrl);
-	for await (const line of x('pnpx', ['giget@latest', 'gh:bombshell-dev/template', name])) {
+	// `.` scaffolds into the current directory; otherwise clone into a new `./<name>/`.
+	const inPlace = _name === '.';
+	const name = inPlace ? basename(cwd()) : _name;
+	const target = inPlace ? '.' : name;
+	const dest = inPlace ? cwdUrl : new URL(`./${name}/`, cwdUrl);
+	const gigetArgs = ['giget@latest', 'gh:bombshell-dev/template', target];
+	// `--force` lets the template extract into an existing (non-empty) directory.
+	if (inPlace) gigetArgs.push('--force');
+	for await (const line of x('pnpx', gigetArgs)) {
 		console.log(line);
 	}
 


### PR DESCRIPTION
## What does this PR do?

Fixes an issue with `bsh init` where post-processing was pointed at a `.tmp` directory that didn't exist

Also fixes an issue where `bsh init` / `bsh init .` wouldn't scaffold in the `cwd` as expected

## Type of change

<!-- Check one. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [ ] All tests pass (`pnpm test`)
- [x] Files are formatted (`pnpm format`)
- [ ] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
